### PR TITLE
Fixes for foxy

### DIFF
--- a/exercises/Perception-Driven_Manipulation/solution_ws/src/industrial_moveit2_utils/package.xml
+++ b/exercises/Perception-Driven_Manipulation/solution_ws/src/industrial_moveit2_utils/package.xml
@@ -6,11 +6,11 @@
   <description>Utilities to load a MoveIt2 Planning environment</description>
   <maintainer email="jrgnichodevel@gmail.com">jnicho</maintainer>
   <license>BSD</license>
-  
-  <buildtool_depend>ament_python</buildtool_depend>
-  
+
   <depend>rclpy</depend>
-  
+
+  <exec_depend>moveit_simple_controller_manager</exec_depend>
+
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>

--- a/exercises/Perception-Driven_Manipulation/solution_ws/src/pick_and_place_application/launch/application_run.launch.py
+++ b/exercises/Perception-Driven_Manipulation/solution_ws/src/pick_and_place_application/launch/application_run.launch.py
@@ -68,7 +68,7 @@ def launch_setup(context, *args, **kwargs):
         package="pick_and_place_application",
         #prefix='xterm -e gdb -ex run --args',
         executable="pick_and_place_node",
-        arguments = '--ros-args --log-level moveit:=error --log-level moveit_ros:=error --log-level ompl:=error'.split(' '),
+        arguments = '--ros-args --log-level info'.split(' '),
         parameters= moveitcpp_parameters + [pick_and_place_parameters],
     )    
     

--- a/exercises/Perception-Driven_Manipulation/solution_ws/src/ur5_workcell_moveit2_config/package.xml
+++ b/exercises/Perception-Driven_Manipulation/solution_ws/src/ur5_workcell_moveit2_config/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
 
   <name>ur5_workcell_moveit2_config</name>
   <version>0.2.0</version>
@@ -13,15 +13,16 @@
   <url type="website">http://moveit.ros.org/</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit_setup_assistant/issues</url>
   <url type="repository">https://github.com/ros-planning/moveit_setup_assistant</url>
-  
+
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <run_depend>moveit_ros_move_group</run_depend>
-  <run_depend>xacro</run_depend>
-  <run_depend>robot_workcell_support</run_depend>
+  <exec_depend>moveit_ros_move_group</exec_depend>
+  <exec_depend>moveit_planners_ompl</exec_depend>
+  <exec_depend>xacro</exec_depend>
+  <exec_depend>robot_workcell_support</exec_depend>
 
   <export>
   	<build_type>ament_cmake</build_type>
   </export>
-  
+
 </package>


### PR DESCRIPTION
Just a few simple things:

- Foxy doesn't support configuring individual loggers
- `ament_python` has long been deprecated and is no longer released
- There were several dependencies missing at runtime that I added to `package.xml`s